### PR TITLE
optionally overwrite default config dir path with environment variable ASYNC_DNS_CONFIG_DIR

### DIFF
--- a/async_dns/core/config/root.py
+++ b/async_dns/core/config/root.py
@@ -12,7 +12,7 @@ __all__ = [
     'get_root_servers',
 ]
 
-CONFIG_DIR = os.path.expanduser('~/.config/async_dns')
+CONFIG_DIR = os.environ.get('ASYNC_DNS_CONFIG_DIR', os.path.expanduser('~/.config/async_dns'))
 os.makedirs(CONFIG_DIR, exist_ok=True)
 CACHE_FILE = os.path.join(CONFIG_DIR, 'named.cache.txt')
 


### PR DESCRIPTION
`$HOME/.config` may not be write-able (e.g. due to `docker run --read-only`)

related issue: https://github.com/home-assistant/core/issues/49205

related commit: https://github.com/gera2ld/async_dns/commit/16cf6361ebfcc62fc6339e5194d013e8a8607fa2